### PR TITLE
feat: Add onPrepareOptionsMenu() in Edit

### DIFF
--- a/app/src/main/java/com/example/excrud/EditActivity.kt
+++ b/app/src/main/java/com/example/excrud/EditActivity.kt
@@ -40,6 +40,12 @@ class EditActivity : AppCompatActivity(), TextWatcher {
 
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+        val deleteItem : MenuItem = menu.findItem(R.id.action_delete)
+        deleteItem.isVisible = intent.hasExtra("content")
+        return true
+    }
+
     private fun initView() {
         initToolbar()
         binding.contentEditText.addTextChangedListener(this)


### PR DESCRIPTION
메모를 생성할 때는 삭제 버튼이 필요 없으므로
create 모드일 때 delete 아이콘을 보이지 않도록 설정했다.